### PR TITLE
Added build dependency on eigen

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
 
   <build_depend>cmake</build_depend>
   <build_depend>boost</build_depend>
+  <build_depend>eigen</build_depend>
 
   <run_depend>boost</run_depend>
 


### PR DESCRIPTION
The binary build of this failed on my internal buildbot...I realised from the error message that it was because there is a build dependency on eigen.
Verified by uninstalling eigen on my own machine and running git-buildpackage locally - also failed looking for eigen
After adding this dependency I ran rosdep install to verify that eigen was pulled in, and then was able to successfully build from source.
